### PR TITLE
Remove uncommented comment that causes an error

### DIFF
--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -160,7 +160,6 @@ class StatTrackerTest < Minitest::Test
     # Name of the Team with the fewest tackles in the season	String
   end
 
-Name of the Team with the fewest tackles in the season	String
   # TEAM STATISTICS
 
   def test_can_get_team_info_hash


### PR DESCRIPTION
Found an uncommented comment that I accidentally pasted in previously. This causes the tests to error due to syntax. @evilaspaas1 @rrabinovitch @gabichuelas 