### PR TITLE
Add empty fixture file and mocks/stubs example

### DIFF
--- a/test/stat_tracker_test.rb
+++ b/test/stat_tracker_test.rb
@@ -57,7 +57,33 @@ class StatTrackerTest < Minitest::Test
   # GAME STATISTICS
 
   def test_highest_total_score
-    assert_equal 5, @stat_tracker.highest_total_score
+
+    #Here I avoid loading the csv data all together
+    #But I still have a real instance of StatTracker to work with
+    game_path = './fixtures/no_data_fixture.csv'
+    team_path = './fixtures/no_data_fixture.csv'
+    game_teams_path = './fixtures/no_data_fixture.csv'
+
+    locations = {
+      games: game_path,
+      teams: team_path,
+      game_teams: game_teams_path
+    }
+    stat_tracker = StatTracker.new(locations)
+    game_1 = mock('game_1')
+    game_2 = mock('game_2')
+    game_3 = mock('game_3')
+    games = [game_1, game_2, game_3]
+    games.each_with_index do |game, index|
+      game.stubs(:total_goals).returns(index)
+    end
+    stat_tracker.stubs(:games).returns(games)
+    assert_equal 2, stat_tracker.highest_total_score
+
+    #If I wanted the csv data for some reason, I could still use
+    #my game mocks
+    @stat_tracker.stubs(:games).returns(games)
+    assert_equal 2, @stat_tracker.highest_total_score
   end
 
   def test_lowest_total_score


### PR DESCRIPTION
### PR Overview

- I added a dummy fixture file with no data, so that I can load up an instance of StatTracker without any objects in it. Fast.
- Then, I added two examples with mocks/stubs to the test_highest_total_score. The first one is the fastest and most preferred. HOWEVER, because you put the @stattracker instance variable in setup, the data is loaded before every test, because the setup method runs before every test. 
- In order to avoid this in this specific test, you would need to ditch the setup method and load up a stattracker instance for each test in the specific way you need it for that test. 